### PR TITLE
Windows: Second build attempt in serial

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,7 +11,7 @@ cmake -B build -S "%SRC_DIR%\src" ^
 if errorlevel 1 exit 1
 
 cmake --build build -- -v -k 0
-cmake --build build -- -v -k 0
+cmake --build build -- -v -k 0 -j 1
 if errorlevel 1 exit 1
 
 cmake --install build --prefix "%STDLIB_DIR%"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     folder : src
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Sometimes Windows builds fail with out of memory errors. On the second attempt, try to build serial (`-j 1`)
